### PR TITLE
Reworking timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Physiqual.configure do |config|
   config.host_protocol        = ENV['HOST_PROTOCOL'] || 'http'
 
   # EMA Settings
-  config.measurements_per_day = 3 # Number of measurements per day, from the end of day downwards
-  config.interval             = 6 # Number of hours between measurements
-  config.use_night            = false # Should the night be included in the first measurement of the day, if there was no questionnaire
+  config.measurements_per_day           = 3 # Number of measurements per day, from the end of day downwards
+  config.interval                       = 6 # Number of hours between measurements
+  config.hours_before_first_measurement = 6 # How many hours before the first measurement each day should be included
 
   # Imputation
   # List of imputers to use, prefix with Physiqual::Imputers::, choose from:

--- a/app/controllers/physiqual/oauth_session_controller.rb
+++ b/app/controllers/physiqual/oauth_session_controller.rb
@@ -8,8 +8,8 @@ module Physiqual
     before_filter :token, only: :callback
 
     def index
-      from = Time.new(2015, 8, 3).in_time_zone.beginning_of_day
-      to = Time.new(2015, 9, 1).in_time_zone.beginning_of_day
+      #from = Time.new(2015, 8, 3).in_time_zone.beginning_of_day
+      #to = Time.new(2015, 9, 1).in_time_zone.beginning_of_day
       # session = Sessions::TokenAuthorizedSession.new(current_user.google_tokens.first.token, GoogleToken.base_uri)
       # session = Sessions::TokenAuthorizedSession.new(current_user.fitbit_tokens.first.token, FitbitToken.base_uri)
       # render json: DataServices::GoogleService.new(session).steps(from, to) and return
@@ -18,17 +18,20 @@ module Physiqual
       # render json: DataServices::GoogleService.new(session).sources and return
       # render json: DataServices::GoogleService.new(session).calories(from, to) and return
       # render json: DataServices::FitbitService.new(session).calories(from, to) and return
-      last_measurement_time = Time.now.change(hour: 22, min: 00)
+      #last_measurement_time = Time.now.change(hour: 22, min: 00)
       # measurements_per_day = 3
       # interval = 6
       # service = DataServices::FitbitService.new(current_user.fitbit_tokens.first)
       # render json: service.heart_rate(from, to) and return
       # render json: DataServices::SummarizedDataService.new(service,
       # last_measurement_time, measurements_per_day, interval, false).steps(from, to) and return
+
+      first_measurement = Time.new(2015, 8, 3, 10, 00).in_time_zone
+      number_of_days = 30
       respond_to do |format|
-        format.html { @values = Exporters::JsonExporter.new.export(current_user, last_measurement_time, from, to) }
-        format.json { render json: Exporters::JsonExporter.new.export(current_user, last_measurement_time, from, to) }
-        format.csv { render text: Exporters::CsvExporter.new.export(current_user, last_measurement_time, from, to) }
+        format.html { @values = Exporters::JsonExporter.new.export(current_user, first_measurement, number_of_days) }
+        format.json { render json: Exporters::JsonExporter.new.export(current_user, first_measurement, number_of_days) }
+        format.csv { render text: Exporters::CsvExporter.new.export(current_user, first_measurement, number_of_days) }
       end
       # render json: FitbitService.new(current_user.fitbit_tokens.first).steps(from, to)
       # render json: FitbitService.new(current_user.fitbit_tokens.first).heart_rate(from, to)

--- a/app/controllers/physiqual/oauth_session_controller.rb
+++ b/app/controllers/physiqual/oauth_session_controller.rb
@@ -8,8 +8,8 @@ module Physiqual
     before_filter :token, only: :callback
 
     def index
-      #from = Time.new(2015, 8, 3).in_time_zone.beginning_of_day
-      #to = Time.new(2015, 9, 1).in_time_zone.beginning_of_day
+      # from = Time.new(2015, 8, 3).in_time_zone.beginning_of_day
+      # to = Time.new(2015, 9, 1).in_time_zone.beginning_of_day
       # session = Sessions::TokenAuthorizedSession.new(current_user.google_tokens.first.token, GoogleToken.base_uri)
       # session = Sessions::TokenAuthorizedSession.new(current_user.fitbit_tokens.first.token, FitbitToken.base_uri)
       # render json: DataServices::GoogleService.new(session).steps(from, to) and return
@@ -18,7 +18,7 @@ module Physiqual
       # render json: DataServices::GoogleService.new(session).sources and return
       # render json: DataServices::GoogleService.new(session).calories(from, to) and return
       # render json: DataServices::FitbitService.new(session).calories(from, to) and return
-      #last_measurement_time = Time.now.change(hour: 22, min: 00)
+      # last_measurement_time = Time.now.change(hour: 22, min: 00)
       # measurements_per_day = 3
       # interval = 6
       # service = DataServices::FitbitService.new(current_user.fitbit_tokens.first)

--- a/lib/physiqual/bucket_generators/bucket_generator.rb
+++ b/lib/physiqual/bucket_generators/bucket_generator.rb
@@ -6,8 +6,9 @@ module Physiqual
       end
 
       # TODO: This is copied from dataservice. Remove it here and find a better place to store it.
-      def output_entry(date, values)
+      def output_entry(start_date, date, values)
         {
+          DataServices::DataService::DATE_TIME_START_FIELD => start_date,
           DataServices::DataService::DATE_TIME_FIELD => date,
           DataServices::DataService::VALUES_FIELD => [values].flatten
         }

--- a/lib/physiqual/bucket_generators/bucket_generator.rb
+++ b/lib/physiqual/bucket_generators/bucket_generator.rb
@@ -5,7 +5,9 @@ module Physiqual
         fail 'Not implemented by subclass'
       end
 
-      # TODO: This is copied from dataservice. Remove it here and find a better place to store it.
+      # Note that this function is no longer equivalent to the output_entry definition from data services.
+      # The below output_entry function is used only for returning data from a bucket generator and
+      # contains additional information about bucket start times.
       def output_entry(start_date, date, values)
         {
           DataServices::DataService::DATE_TIME_START_FIELD => start_date,

--- a/lib/physiqual/bucket_generators/daily_bucket_generator.rb
+++ b/lib/physiqual/bucket_generators/daily_bucket_generator.rb
@@ -16,7 +16,7 @@ module Physiqual
           @measurement_moments.each_with_index do |measurement, measurement_index|
             bucket_start = bucket_end
             bucket_end = date.to_time.change(hour: measurement.hour,
-                                             min: measurement.min).to_time.in_time_zone
+                                             min: measurement.min).in_time_zone
             bucket_start = bucket_end - @hours_before_first_measurement.hours if measurement_index == 0
 
             # Only use dates that are in the past

--- a/lib/physiqual/bucket_generators/daily_bucket_generator.rb
+++ b/lib/physiqual/bucket_generators/daily_bucket_generator.rb
@@ -2,21 +2,25 @@ module Physiqual
   module BucketGenerators
     class DailyBucketGenerator
       include BucketGenerator
-      def initialize(measurement_moments)
+      def initialize(measurement_moments, hours_before_first_measurement)
         @measurement_moments = measurement_moments
+        @hours_before_first_measurement = hours_before_first_measurement
       end
 
       def generate(from, to)
         from = from.beginning_of_day.to_datetime
         to = to.beginning_of_day.to_datetime
         result = []
-        from.to_date.upto(to.to_date).each_with_index do |date|
-          @measurement_moments.each do |measurement|
-            current = date.to_time.change(hour: measurement.hour,
-                                          min: measurement.min)
+        from.to_date.upto(to.to_date).each do |date|
+          bucket_end = -1
+          @measurement_moments.each_with_index do |measurement, measurement_index|
+            bucket_start = bucket_end
+            bucket_end = date.to_time.change(hour: measurement.hour,
+                                             min: measurement.min).to_time.in_time_zone
+            bucket_start = bucket_end - @hours_before_first_measurement.hours if measurement_index == 0
 
             # Only use dates that are in the past
-            result << output_entry(current.to_time, []) if date < Time.zone.now
+            result << output_entry(bucket_start, bucket_end, []) if bucket_end < Time.zone.now
           end
         end
         result

--- a/lib/physiqual/bucket_generators/equidistant_bucket_generator.rb
+++ b/lib/physiqual/bucket_generators/equidistant_bucket_generator.rb
@@ -14,16 +14,16 @@ module Physiqual
         bucket_start = -1
         bucket_end = -1
         result = []
-        while true do
+        loop do
           @measurements_per_day.times do |measurement_index|
-            if measurement_index == 0 then
+            if measurement_index == 0
               bucket_start = first_measurement_of_the_day
               bucket_end   = bucket_start + @hours_before_first_measurement.hours
             else
               bucket_start = bucket_end
               bucket_end   = bucket_start + @interval.hours
             end
-            return result if (bucket_end > to || bucket_end >= currently)
+            return result if bucket_end > to || bucket_end >= currently
             result << output_entry(bucket_start, bucket_end, [])
           end
           first_measurement_of_the_day += 1.day

--- a/lib/physiqual/bucket_generators/equidistant_bucket_generator.rb
+++ b/lib/physiqual/bucket_generators/equidistant_bucket_generator.rb
@@ -2,25 +2,31 @@ module Physiqual
   module BucketGenerators
     class EquidistantBucketGenerator
       include BucketGenerator
-      def initialize(measurements_per_day, interval, last_measurement_time)
+      def initialize(measurements_per_day, interval, hours_before_first_measurement)
         @measurements_per_day = measurements_per_day
         @interval = interval
-        @last_measurement_time = last_measurement_time
+        @hours_before_first_measurement = hours_before_first_measurement
       end
 
       def generate(from, to)
-        from = from.beginning_of_day.to_datetime
-        to = to.beginning_of_day.to_datetime
+        currently = Time.zone.now
+        first_measurement_of_the_day = from
+        bucket_start = -1
+        bucket_end = -1
         result = []
-        start = @last_measurement_time.hour - ((@measurements_per_day - 1) * @interval)
-        from.to_date.upto(to.to_date).map do |date|
-          (0...@measurements_per_day).map do |measurement|
-            current = date.to_time.change(hour: start + (measurement * @interval),
-                                          min: @last_measurement_time.min)
-
-            # Only use dates that are in the past
-            result << output_entry(current.to_time, []) if date < Time.zone.now
+        while true do
+          @measurements_per_day.times do |measurement_index|
+            if measurement_index == 0 then
+              bucket_start = first_measurement_of_the_day
+              bucket_end   = bucket_start + @hours_before_first_measurement.hours
+            else
+              bucket_start = bucket_end
+              bucket_end   = bucket_start + @interval.hours
+            end
+            return result if (bucket_end > to || bucket_end >= currently)
+            result << output_entry(bucket_start, bucket_end, [])
           end
+          first_measurement_of_the_day += 1.day
         end
         result
       end

--- a/lib/physiqual/data_aggregator.rb
+++ b/lib/physiqual/data_aggregator.rb
@@ -24,6 +24,7 @@ module Physiqual
     def sleep(from, to)
       result = retrieve_data_of_all_services { |service| service.sleep(from, to) }
       run_function(result) do |sleep_data, data_entry|
+        # TODO: Mist hier een .flatten?
         [sleep_data[data_entry[DataServices::DataService::DATE_TIME_FIELD]],
          data_entry[DataServices::DataService::VALUES_FIELD]].max
       end

--- a/lib/physiqual/data_services/data_service.rb
+++ b/lib/physiqual/data_services/data_service.rb
@@ -3,6 +3,7 @@ module Physiqual
     class DataService
       DATE_FORMAT = '%Y-%m-%d'
       DATE_TIME_FIELD = 'dateTime'
+      DATE_TIME_START_FIELD = 'dateTimeStart'
       VALUES_FIELD = 'values'
 
       def service_name
@@ -31,6 +32,10 @@ module Physiqual
 
       def date_time_field
         DATE_TIME_FIELD
+      end
+
+      def date_time_start_field
+        DATE_TIME_START_FIELD
       end
 
       def values_field

--- a/lib/physiqual/data_services/summarized_data_service.rb
+++ b/lib/physiqual/data_services/summarized_data_service.rb
@@ -1,16 +1,14 @@
 module Physiqual
   module DataServices
     class SummarizedDataService < DataServiceDecorator
-      def initialize(data_service, last_measurement_time, measurements_per_day, interval,
-                     hours_before_first_measurement)
+      def initialize(data_service, measurements_per_day, interval, hours_before_first_measurement)
         super(data_service)
-        @last_measurement_time = last_measurement_time
         @measurements_per_day = measurements_per_day
         @interval = interval
         @hours_before_first_measurement = hours_before_first_measurement
         @bucket_generator = BucketGenerators::EquidistantBucketGenerator.new(measurements_per_day,
                                                                              interval,
-                                                                             last_measurement_time)
+                                                                             hours_before_first_measurement)
       end
 
       def service_name
@@ -89,8 +87,7 @@ module Physiqual
         buckets = @bucket_generator.generate(from, to)
         current_bucket = 0
 
-        # Sort both arrays
-        buckets.sort_by! { |entry| entry[date_time_field] }
+        # Sort data array
         data.sort_by! { |entry| entry[date_time_field] }
 
         data.each do |entry|
@@ -104,8 +101,7 @@ module Physiqual
           break if current_bucket == buckets.size
 
           # Don't take the night into account
-          unless entry[date_time_field] > (buckets[current_bucket][date_time_field] -
-                  @hours_before_first_measurement.hours)
+          unless entry[date_time_field] > buckets[current_bucket][date_time_start_field]
             next
           end
           values = entry[values_field]
@@ -113,6 +109,10 @@ module Physiqual
           # TODO: Should be no need to flatten the entire thing every time.
           # TODO: Just flatten whatever you add before adding it and check that your concat works correctly.
           buckets[current_bucket][values_field] = buckets[current_bucket][values_field].flatten
+        end
+        # remove the extra information
+        buckets.each_with_index do |_bucket, bucket_index|
+          buckets[bucket_index].delete(date_time_start_field)
         end
         buckets
       end

--- a/lib/physiqual/data_services/summarized_data_service.rb
+++ b/lib/physiqual/data_services/summarized_data_service.rb
@@ -1,12 +1,13 @@
 module Physiqual
   module DataServices
     class SummarizedDataService < DataServiceDecorator
-      def initialize(data_service, last_measurement_time, measurements_per_day, interval, use_night)
+      def initialize(data_service, last_measurement_time, measurements_per_day, interval,
+                     hours_before_first_measurement)
         super(data_service)
         @last_measurement_time = last_measurement_time
         @measurements_per_day = measurements_per_day
         @interval = interval
-        @use_night = use_night
+        @hours_before_first_measurement = hours_before_first_measurement
         @bucket_generator = BucketGenerators::EquidistantBucketGenerator.new(measurements_per_day,
                                                                              interval,
                                                                              last_measurement_time)
@@ -103,7 +104,8 @@ module Physiqual
           break if current_bucket == buckets.size
 
           # Don't take the night into account
-          unless entry[date_time_field] > (buckets[current_bucket][date_time_field] - @interval.hours) || @use_night
+          unless entry[date_time_field] > (buckets[current_bucket][date_time_field] -
+                  @hours_before_first_measurement.hours)
             next
           end
           values = entry[values_field]

--- a/lib/physiqual/engine.rb
+++ b/lib/physiqual/engine.rb
@@ -9,7 +9,7 @@ module Physiqual
     mattr_accessor :host_protocol
     mattr_accessor :measurements_per_day
     mattr_accessor :interval
-    mattr_accessor :use_night
+    mattr_accessor :hours_before_first_measurement
     mattr_accessor :imputers
   end
 

--- a/lib/physiqual/exporters/csv_exporter.rb
+++ b/lib/physiqual/exporters/csv_exporter.rb
@@ -3,8 +3,8 @@ require 'csv'
 module Physiqual
   module Exporters
     class CsvExporter < Exporter
-      def export(user, last_measurement_time, from, to)
-        result = export_data(user, last_measurement_time, from, to)
+      def export(user, first_measurement, number_of_days)
+        result = export_data(user, first_measurement, number_of_days)
         Rails.logger.debug result
 
         csv_string = CSV.generate do |csv|

--- a/lib/physiqual/exporters/exporter.rb
+++ b/lib/physiqual/exporters/exporter.rb
@@ -34,7 +34,7 @@ module Physiqual
                                                             last_measurement_time,
                                                             Physiqual.measurements_per_day,
                                                             Physiqual.interval,
-                                                            Physiqual.use_night)
+                                                            Physiqual.hours_before_first_measurement)
 
           DataServices::CachedDataService.new service
         end.compact

--- a/lib/physiqual/exporters/exporter.rb
+++ b/lib/physiqual/exporters/exporter.rb
@@ -2,21 +2,42 @@ module Physiqual
   module Exporters
     class Exporter
       def export_data(user, first_measurement, number_of_days)
-        services = create_services(user.physiqual_tokens)
+        bucket_generator = BucketGenerators::EquidistantBucketGenerator.new(
+          Physiqual.measurements_per_day,
+          Physiqual.interval,
+          Physiqual.hours_before_first_measurement)
+        services = create_services(user.physiqual_tokens, bucket_generator)
         data_aggregator = DataAggregator.new(services, Physiqual.imputers)
 
         from = first_measurement - Physiqual.hours_before_first_measurement.hours
         to   = first_measurement + (number_of_days - 1).days +
                ((Physiqual.measurements_per_day - 1) * Physiqual.interval).hours
 
+        buckets = bucket_generator.generate(from, to)
+        aggregate_data_into_buckets(from, to, data_aggregator, buckets)
+      end
+
+      private
+
+      def create_services(tokens, bucket_generator)
+        tokens.map do |token|
+          next unless token.complete?
+          session = Sessions::TokenAuthorizedSession.new(token.token, token.class.base_uri)
+          service = DataServices::DataServiceFactory.fabricate!(token.class.csrf_token, session)
+          service = DataServices::SummarizedDataService.new(service, bucket_generator)
+          DataServices::CachedDataService.new service
+        end.compact
+      end
+
+      def aggregate_data_into_buckets(from, to, data_aggregator, buckets)
         activities = data_aggregator.activities(from, to)
         heart_rate = data_aggregator.heart_rate(from, to)
         steps = data_aggregator.steps(from, to)
         calories = data_aggregator.calories(from, to)
 
         result = {}
-        # TODO: Waarom index je dit op de dates steps en itereer je niet gewoon over alle dates?
-        steps.keys.each do |date|
+        buckets.each do |bucket|
+          date = bucket[DataServices::DataService::DATE_TIME_FIELD]
           result[date] = {}
           result[date][:heart_rate] = heart_rate[date]
           result[date][:steps] = steps[date]
@@ -25,22 +46,6 @@ module Physiqual
           result[date][:activities] = activities[date]
         end
         result
-      end
-
-      private
-
-      def create_services(tokens)
-        tokens.map do |token|
-          next unless token.complete?
-          session = Sessions::TokenAuthorizedSession.new(token.token, token.class.base_uri)
-          service = DataServices::DataServiceFactory.fabricate!(token.class.csrf_token, session)
-          service = DataServices::SummarizedDataService.new(service,
-                                                            Physiqual.measurements_per_day,
-                                                            Physiqual.interval,
-                                                            Physiqual.hours_before_first_measurement)
-
-          DataServices::CachedDataService.new service
-        end.compact
       end
     end
   end

--- a/lib/physiqual/exporters/json_exporter.rb
+++ b/lib/physiqual/exporters/json_exporter.rb
@@ -1,8 +1,8 @@
 module Physiqual
   module Exporters
     class JsonExporter < Exporter
-      def export(user, last_measurement_time, from, to)
-        result = export_data(user, last_measurement_time, from, to)
+      def export(user, first_measurement, number_of_days)
+        result = export_data(user, first_measurement, number_of_days)
         result.to_json
       end
     end

--- a/spec/dummy/config/initializers/physiqual.rb
+++ b/spec/dummy/config/initializers/physiqual.rb
@@ -12,9 +12,9 @@ Physiqual.configure do |config|
   config.host_protocol        = ENV['HOST_PROTOCOL'] || 'http'
 
   # EMA Settings
-  config.measurements_per_day = 3 # Number of measurements per day, from the end of day downwards
-  config.interval             = 6 # Number of hours between measurements
-  config.use_night            = false
+  config.measurements_per_day           = 3 # Number of measurements per day, from the end of day downwards
+  config.interval                       = 6 # Number of hours between measurements
+  config.hours_before_first_measurement = 6
 
   # Imputation
   config.imputers             = [Physiqual::Imputers::CatMullImputer]

--- a/spec/dummy/config/initializers/physiqual.rb
+++ b/spec/dummy/config/initializers/physiqual.rb
@@ -12,9 +12,9 @@ Physiqual.configure do |config|
   config.host_protocol        = ENV['HOST_PROTOCOL'] || 'http'
 
   # EMA Settings
-  config.measurements_per_day           = 3 # Number of measurements per day, from the end of day downwards
+  config.measurements_per_day           = 3 # Number of measurements per day
   config.interval                       = 6 # Number of hours between measurements
-  config.hours_before_first_measurement = 6
+  config.hours_before_first_measurement = 6 # Number of hours before the first measurement on a day
 
   # Imputation
   config.imputers             = [Physiqual::Imputers::CatMullImputer]

--- a/spec/lib/physiqual/bucket_generators/daily_bucket_generator_spec.rb
+++ b/spec/lib/physiqual/bucket_generators/daily_bucket_generator_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-require 'shared_context_for_data_services'
+require 'shared_context_for_bucket_generators'
 module Physiqual
   module BucketGenerators
     describe DailyBucketGenerator do
@@ -12,9 +12,10 @@ module Physiqual
           Time.zone.now.change(hour: 23, min: 30, usec: 0)
         ]
       end
-      let(:subject) { described_class.new(measurement_times) }
+      let(:hours_before_first_measurement) { 6 }
+      let(:subject) { described_class.new(measurement_times, hours_before_first_measurement) }
 
-      include_context 'data_service context'
+      include_context 'bucket_generator context'
 
       describe 'generate' do
         before do

--- a/spec/lib/physiqual/bucket_generators/equidistant_bucket_generator_spec.rb
+++ b/spec/lib/physiqual/bucket_generators/equidistant_bucket_generator_spec.rb
@@ -6,10 +6,10 @@ module Physiqual
     describe EquidistantBucketGenerator do
       let(:interval) { 6 }
       let(:measurements_per_day) { 3 }
-      let(:last_measurement_time) { Time.now.change(hour: 22, min: 30, usec: 0) }
-      let(:subject) { described_class.new(measurements_per_day, interval, last_measurement_time) }
+      let(:hours_before_first_measurement) { 6 }
+      let(:subject) { described_class.new(measurements_per_day, interval, hours_before_first_measurement) }
 
-      include_context 'data_service context'
+      include_context 'bucket_generator context'
 
       describe 'generate' do
         before do
@@ -35,7 +35,7 @@ module Physiqual
         end
 
         it 'should generate time buckets as expected' do
-          start = last_measurement_time - (interval * (measurements_per_day - 1)).hours
+          start = from + hours_before_first_measurement.hours
           current = start.dup
           @dates.each_with_index do |date, index|
             expect(date.hour).to eq current.hour

--- a/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
+++ b/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
@@ -16,9 +16,9 @@ module Physiqual
       let(:service) { MockService.new(nil) }
       let(:subject) do
         SummarizedDataService.new(service,
-                                  last_measurement_time,
                                   measurements_per_day,
-                                  interval, interval) # use_night == false
+                                  interval,
+                                  interval) # use_night == false
       end
 
       it_behaves_like 'a data_service'
@@ -26,28 +26,22 @@ module Physiqual
 
       describe 'cluster_in_buckets' do
         let(:data) { service.steps(from, to) }
-        let(:from_subset) { (to - 1.day).beginning_of_day }
-        let(:to_subset) { (to - 1.day).end_of_day }
+        let(:from_subset) { (to - 1.day).change(hour: 10, min: 30) - interval.hours }
+        let(:to_subset) { (to - 1.day).change(hour: 22, min: 30) }
         let(:data_subset) { data.select! { |x| x[subject.date_time_field].to_date == (from_subset).to_date } }
 
         it 'should output the correct format' do
-          @result = subject.send(:cluster_in_buckets, data, from, to)
+          @result = subject.send(:cluster_in_buckets, data, from_subset, to_subset)
           check_result_format(@result)
         end
 
         it 'should correctly cluster the data into buckets' do
           res = []
-
-          last_measuremnt_date_time = from_subset.change(hour: last_measurement_time.hour,
-                                                         min: last_measurement_time.min)
           (0...measurements_per_day).each do |meas|
-            beginn = last_measuremnt_date_time - ((meas + 1) * interval).hours
-            endd = last_measuremnt_date_time - (meas * interval).hours
+            beginn = from_subset + (meas * interval).hours
+            endd = from_subset + ((meas + 1) * interval).hours
             res << data.select { |x| x[subject.date_time_field] <= endd && x[subject.date_time_field] > beginn }
           end
-
-          # The results in this example are the other way around, reverse them
-          res.reverse!
 
           full_result = subject.send(:cluster_in_buckets, data, from_subset, to_subset)
           res.each_with_index do |current_res, index|
@@ -62,14 +56,12 @@ module Physiqual
         describe 'should take the night flag into account' do
           before do
             subject = SummarizedDataService.new(service,
-                                                last_measurement_time,
                                                 measurements_per_day,
                                                 interval, hours_before_first_measurement)
             full_with_night = subject.send(:cluster_in_buckets, data, from_subset, to_subset)
             @full_with_night = full_with_night.first[subject.values_field].sort
 
             subject = SummarizedDataService.new(service,
-                                                last_measurement_time,
                                                 measurements_per_day,
                                                 interval, interval)
             full_without_night = subject.send(:cluster_in_buckets, data, from_subset, to_subset)

--- a/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
+++ b/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
@@ -12,12 +12,13 @@ module Physiqual
       let(:last_measurement_time) { Time.now.change(hour: 22, min: 30, usec: 0) }
       let(:interval) { 6 }
       let(:measurements_per_day) { 3 }
+      let(:hours_before_first_measurement) { 12 } # previously: use_night == true
       let(:service) { MockService.new(nil) }
       let(:subject) do
         SummarizedDataService.new(service,
                                   last_measurement_time,
                                   measurements_per_day,
-                                  interval, false)
+                                  interval, interval) # use_night == false
       end
 
       it_behaves_like 'a data_service'
@@ -63,14 +64,14 @@ module Physiqual
             subject = SummarizedDataService.new(service,
                                                 last_measurement_time,
                                                 measurements_per_day,
-                                                interval, true)
+                                                interval, hours_before_first_measurement)
             full_with_night = subject.send(:cluster_in_buckets, data, from_subset, to_subset)
             @full_with_night = full_with_night.first[subject.values_field].sort
 
             subject = SummarizedDataService.new(service,
                                                 last_measurement_time,
                                                 measurements_per_day,
-                                                interval, false)
+                                                interval, interval)
             full_without_night = subject.send(:cluster_in_buckets, data, from_subset, to_subset)
             @full_without_night = full_without_night.first[subject.values_field].sort
           end

--- a/spec/lib/physiqual/exporters/csv_exporter_spec.rb
+++ b/spec/lib/physiqual/exporters/csv_exporter_spec.rb
@@ -11,10 +11,10 @@ module Physiqual
       describe 'export' do
         before do
           allow_any_instance_of(Exporter)
-            .to receive(:export_data).with(user, last_measurement_time, from, to)
+            .to receive(:export_data).with(user, first_measurement, number_of_days)
             .and_return(mock_result)
 
-          @result = subject.export(user, last_measurement_time, from, to)
+          @result = subject.export(user, first_measurement, number_of_days)
         end
 
         it 'should respond with CSV' do

--- a/spec/lib/physiqual/exporters/exporter_spec.rb
+++ b/spec/lib/physiqual/exporters/exporter_spec.rb
@@ -21,7 +21,7 @@ module Physiqual
         it 'should create services for each correct token provided' do
           tokens = [FactoryGirl.build(:fitbit_token), FactoryGirl.build(:google_token)]
           expect(tokens.all?(&:complete?)).to be_truthy
-          result = subject.send(:create_services, tokens, last_measurement_time)
+          result = subject.send(:create_services, tokens)
           expect(result.length).to eq(2)
         end
 
@@ -31,7 +31,7 @@ module Physiqual
             allow(tokens.first).to receive(:complete?).and_return(false)
             expect(tokens.all?(&:complete?)).to be_falsey
 
-            @result = subject.send(:create_services, tokens, last_measurement_time)
+            @result = subject.send(:create_services, tokens)
           end
 
           it 'should not create a service for a token which is not complete' do

--- a/spec/lib/physiqual/exporters/json_exporter_spec.rb
+++ b/spec/lib/physiqual/exporters/json_exporter_spec.rb
@@ -11,12 +11,12 @@ module Physiqual
       describe 'export' do
         before do
           allow_any_instance_of(Exporter)
-            .to receive(:export_data).with(user, last_measurement_time, from, to)
+            .to receive(:export_data).with(user, first_measurement, number_of_days)
             .and_return(mock_result)
         end
 
         it 'should respond with JSON' do
-          result = subject.export(user, last_measurement_time, from, to)
+          result = subject.export(user, first_measurement, number_of_days)
           expect(json? result).to be_truthy
         end
       end

--- a/spec/shared_context_for_bucket_generators.rb
+++ b/spec/shared_context_for_bucket_generators.rb
@@ -1,0 +1,30 @@
+module Physiqual
+  module BucketGenerators
+    shared_context 'bucket_generator context' do
+      let(:from) { Time.new(2015, 7, 4, 3, 0).in_time_zone }
+      let(:to) { Time.new(2015, 8, 4, 21, 0).in_time_zone }
+      def check_result_format(result)
+        expect(result).to be_a Array
+        result.each do |entry|
+          expect(entry).to be_a Hash
+          expect(entry.keys.length).to eq 3
+          expect(entry.keys).to include Physiqual::DataServices::DataService.new.date_time_field
+          expect(entry.keys).to include Physiqual::DataServices::DataService.new.date_time_start_field
+          expect(entry.keys).to include Physiqual::DataServices::DataService.new.values_field
+          expect(entry[Physiqual::DataServices::DataService.new.date_time_field]).to be_a ActiveSupport::TimeWithZone
+          expect(entry[Physiqual::DataServices::DataService.new.date_time_start_field]).to be_a ActiveSupport::TimeWithZone
+          expect(entry[Physiqual::DataServices::DataService.new.values_field]).to be_a Array
+          expect(entry[Physiqual::DataServices::DataService.new.values_field].any? { |x| x.is_a? Array }).to be_falsey
+        end
+      end
+
+      def check_start_end_date(result, from, to)
+        dates = result.map { |x| x[Physiqual::DataServices::DataService.new.date_time_field] }
+        lowest_date = dates.min
+        highest_date = dates.max
+        expect(lowest_date).to be_between(from.beginning_of_day, to.end_of_day)
+        expect(highest_date).to be_between(from.beginning_of_day, to.end_of_day)
+      end
+    end
+  end
+end

--- a/spec/shared_context_for_bucket_generators.rb
+++ b/spec/shared_context_for_bucket_generators.rb
@@ -12,7 +12,8 @@ module Physiqual
           expect(entry.keys).to include Physiqual::DataServices::DataService.new.date_time_start_field
           expect(entry.keys).to include Physiqual::DataServices::DataService.new.values_field
           expect(entry[Physiqual::DataServices::DataService.new.date_time_field]).to be_a ActiveSupport::TimeWithZone
-          expect(entry[Physiqual::DataServices::DataService.new.date_time_start_field]).to be_a ActiveSupport::TimeWithZone
+          expect(entry[Physiqual::DataServices::DataService.new.date_time_start_field]).to be_a(
+            ActiveSupport::TimeWithZone)
           expect(entry[Physiqual::DataServices::DataService.new.values_field]).to be_a Array
           expect(entry[Physiqual::DataServices::DataService.new.values_field].any? { |x| x.is_a? Array }).to be_falsey
         end

--- a/spec/shared_context_for_exporters.rb
+++ b/spec/shared_context_for_exporters.rb
@@ -2,9 +2,8 @@ module Physiqual
   module Exporters
     shared_context 'exporter context' do
       let(:user) { FactoryGirl.create(:physiqual_user) }
-      let(:last_measurement_time) { Time.now.change(hour: 22, min: 00) }
-      let(:from) { Time.new(2015, 7, 4, 0, 0).in_time_zone }
-      let(:to) { Time.new(2015, 8, 4, 0, 0).in_time_zone }
+      let(:first_measurement) { Time.new(2015, 7, 4, 10, 0).in_time_zone }
+      let(:number_of_days) { 1 }
       let(:mock_result) do
         {
           '2015-08-03 10:00:00 +0200' => { heart_rate: 87.0, steps: 924, calories: 17, activities: 'Walking' },

--- a/spec/shared_examples_for_exporters.rb
+++ b/spec/shared_examples_for_exporters.rb
@@ -15,9 +15,9 @@ module Physiqual
 
         it 'should call the export_data method when called' do
           expect_any_instance_of(Exporter)
-            .to receive(:export_data).with(user, last_measurement_time, from, to)
+            .to receive(:export_data).with(user, first_measurement, number_of_days)
             .and_return(mock_result)
-          subject.export(user, last_measurement_time, from, to)
+          subject.export(user, first_measurement, number_of_days)
         end
       end
     end


### PR DESCRIPTION
The `use_night` setting was replaced with the `hours_before_first_measurement` setting. This works with both the equidistant bucket generator as well as the daily bucket generator.

An export data request now only takes two parameters: `first_measurement` and `number_of_days`. The first_measurement is the date and time of the first measurement of the diary study for a user. For equidistant time intervals, the schedule for the measurements is derived by looking at the time of this measurement. The number of days is the number of days the user followed the diary study.

Only the exporter knows the start time and number of measurements for a user's diary study. The DataServices and bucket generator objects only know project global measurements_per_day, interval, and hours_before_first_measurement variables. The data ranges are captured using `from` and `to` arguments which are constructed by the exporter.

The `from` argument is the first time at which we want to start considering data points for this user. It is defined by the exporter as `first_measurement - hours_before_first_measurement.hours`. Note that this can fall on a previous day, which is fine. The `to` argument is the last time after which we stop considering data points. This is the time of the last measurement on the last day of the diary study of the user.

The methods that query the Google and Fitbit services receive the `from` and `to` arguments, and convert those either to dates or to nanosecond time offsets: either way they work to capture at least all and possibly more data than we are interested in. Possible data measurements that we receive from Google or Fitbit that we are not interested in (i.e., that occurred either before the `from`, after the `to` or during the night (which is defined by the engine global variable `Physiqual.hours_before_first_measurement`)) are discarded by the SummarizedDataService.

The SummarizedDataServices discards the extra measurements using extra information returned by the bucket generator. In addition to the end datetimestamp of each bucket, the bucket generator now also returns the start time for each bucket. This start time is defined as either the end time - hours_before_first_measurement for the first measurement of the day, or as the end time of the previous measurement on that day. This works with both the Equidistant bucket generator as well as the daily bucket generator. Having both the start and end ranges for each bucket, the SummarizedDataService now knows which data to discard. It also discards the extra bucket start time information so that its output is compatible with those of other data services.
