### PR TITLE
Implemented alternative tie-breaking scheme

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,10 @@ MethodLength:
 Metrics/ModuleLength:
   Max: 200
 
+# Limit classes to have a length of 200
+Metrics/ClassLength:
+  Max: 200
+
 ################################################################## DISABLED COPS
 # These cops are disabled because we think they are a Bad Idea. If you add one
 # here, make sure to add a comment describing what the cop does, and why this

--- a/lib/physiqual/data_services/google_service.rb
+++ b/lib/physiqual/data_services/google_service.rb
@@ -1,6 +1,6 @@
 module Physiqual
   module DataServices
-    # rubocop:disable Metrics/ClassLength, Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength
     class GoogleService < DataService
       def initialize(session)
         @session = session
@@ -218,6 +218,6 @@ module Physiqual
         activities[number]
       end
     end
-    # rubocop:enable Metrics/ClassLength, Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/physiqual/data_services/summarized_data_service.rb
+++ b/lib/physiqual/data_services/summarized_data_service.rb
@@ -84,27 +84,37 @@ module Physiqual
 
       def representative_value_for_array(max_values)
         max_values.sort!
-        number_of_elements = max_values.length
-        average_max_value = max_values.sum.to_f / number_of_elements
-        largest_value_smaller_than_mean = max_values[0]
-        smallest_value_larger_than_mean = max_values[-1]
-        number_of_elements.times do |i|
-          largest_value_smaller_than_mean = max_values[i] if max_values[i] < average_max_value
-          smallest_value_larger_than_mean = max_values[number_of_elements - i - 1] if
-                  max_values[number_of_elements - i - 1] >= average_max_value
-        end
-        closest_value(smallest_value_larger_than_mean, largest_value_smaller_than_mean, average_max_value)
+        average_max_value = max_values.sum.to_f / max_values.size
+        lower_bound, upper_bound = lower_and_upper_bounds(max_values, average_max_value)
+        closest_value(max_values[lower_bound], max_values[upper_bound], average_max_value)
       end
 
-      def closest_value(smallest_value_larger_than_mean, largest_value_smaller_than_mean, average_max_value)
-        if (smallest_value_larger_than_mean - largest_value_smaller_than_mean).abs < 1e-6
-          smallest_value_larger_than_mean
-        elsif smallest_value_larger_than_mean - average_max_value == average_max_value - largest_value_smaller_than_mean
-          smallest_value_larger_than_mean
-        elsif smallest_value_larger_than_mean - average_max_value > average_max_value - largest_value_smaller_than_mean
-          largest_value_smaller_than_mean
+      def lower_and_upper_bounds(arr, value)
+        return [0, 0] if arr.size == 1
+        return [0, 0] if value <= arr[0] # does not occur, included for correctness only
+        return [arr.size - 1, arr.size - 1] if value > arr[-1] # does not occur, included for correctness only
+        l = 0
+        r = arr.size - 1
+        while l + 1 != r
+          m = (l + r) >> 1
+          if arr[m] >= value
+            r = m
+          else
+            l = m
+          end
+        end
+        [l, r]
+      end
+
+      def closest_value(lower_bound, upper_bound, average_max_value)
+        if (upper_bound - lower_bound).abs < 1e-6
+          upper_bound
+        elsif upper_bound - average_max_value == average_max_value - lower_bound
+          upper_bound
+        elsif upper_bound - average_max_value > average_max_value - lower_bound
+          lower_bound
         else
-          smallest_value_larger_than_mean
+          upper_bound
         end
       end
 

--- a/lib/physiqual/data_services/summarized_data_service.rb
+++ b/lib/physiqual/data_services/summarized_data_service.rb
@@ -79,6 +79,10 @@ module Physiqual
         return nil unless provided_hash.max
         max_values = provided_hash.map { |key, v| key if v == provided_hash.values.max }.compact
         return max_values.first if max_values.any? { |elem| elem.is_a? String }
+        representative_value_for_array(max_values)
+      end
+
+      def representative_value_for_array(max_values)
         max_values.sort!
         number_of_elements = max_values.length
         average_max_value = max_values.sum.to_f / number_of_elements

--- a/lib/physiqual/data_services/summarized_data_service.rb
+++ b/lib/physiqual/data_services/summarized_data_service.rb
@@ -107,7 +107,7 @@ module Physiqual
       end
 
       def closest_value(lower_bound, upper_bound, average_max_value)
-        if (upper_bound - lower_bound).abs < 1e-6
+        if upper_bound == lower_bound
           upper_bound
         elsif upper_bound - average_max_value == average_max_value - lower_bound
           upper_bound

--- a/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
+++ b/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
@@ -120,6 +120,44 @@ module Physiqual
         end
       end
 
+      describe 'lower_and_upper_bounds' do
+        it 'works when there is just one item' do
+          data = [3]
+          result = subject.send(:lower_and_upper_bounds, data, 3)
+          expect(result).to eq([0, 0])
+        end
+
+        it 'works when there are two items' do
+          data = [0, 1]
+          result = subject.send(:lower_and_upper_bounds, data, 0.5)
+          expect(result).to eq([0, 1])
+        end
+
+        it 'returns the enclosing boundaries when none match' do
+          data = [1, 4, 5, 9, 10, 11, 12, 14]
+          result = subject.send(:lower_and_upper_bounds, data, 9.5)
+          expect(result).to eq([3, 4])
+          result = subject.send(:lower_and_upper_bounds, data, 8)
+          expect(result).to eq([2, 3])
+          result = subject.send(:lower_and_upper_bounds, data, 13.5)
+          expect(result).to eq([6, 7])
+          result = subject.send(:lower_and_upper_bounds, data, 1)
+          expect(result).to eq([0, 0])
+        end
+
+        it 'returns the matching boundary as the highest one when there is one' do
+          data = [1, 4, 5, 9, 10, 11, 12, 14]
+          result = subject.send(:lower_and_upper_bounds, data, 12.0)
+          expect(result).to eq([5, 6])
+          result = subject.send(:lower_and_upper_bounds, data, 12)
+          expect(result).to eq([5, 6])
+          result = subject.send(:lower_and_upper_bounds, data, 4)
+          expect(result).to eq([0, 1])
+          result = subject.send(:lower_and_upper_bounds, data, 14)
+          expect(result).to eq([6, 7])
+        end
+      end
+
       describe 'closest_value' do
         it 'returns the value when both values are the same' do
           result = subject.send(:closest_value, 3, 3, 3)
@@ -127,17 +165,17 @@ module Physiqual
         end
 
         it 'returns the larger value if the values are equidistant from mean' do
-          result = subject.send(:closest_value, 4, 3, 3.5)
+          result = subject.send(:closest_value, 3, 4, 3.5)
           expect(result).to eq(4)
         end
 
         it 'returns the smaller value if it is closer to the mean' do
-          result = subject.send(:closest_value, 4, 3, 3.4)
+          result = subject.send(:closest_value, 3, 4, 3.4)
           expect(result).to eq(3)
         end
 
         it 'returns the larger value if it is closer to the mean' do
-          result = subject.send(:closest_value, 4, 3, 3.7)
+          result = subject.send(:closest_value, 3, 4, 3.7)
           expect(result).to eq(4)
         end
       end

--- a/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
+++ b/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
@@ -80,10 +80,10 @@ module Physiqual
       end
 
       describe 'max_from_hash' do
-        it 'always gets the median max value on a tie' do
+        it 'always gets the highest value closest to the mean of the max values on a tie' do
           data = { 1 => 1, 2 => 1, 3 => 1, 4 => 1 }
           result = subject.send(:max_from_hash, data)
-          expect(result).to eq(2.5)
+          expect(result).to eq(3)
         end
 
         it 'returns the highest value from a hash of values' do

--- a/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
+++ b/spec/lib/physiqual/data_services/summarized_data_service_spec.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ModuleLength
 module Physiqual
   require 'rails_helper'
 
@@ -102,6 +103,42 @@ module Physiqual
           data = { 'test 1' => 1, 'test2' => 1, 'test3' => 1 }
           result = subject.send(:max_from_hash, data)
           expect(result).to eq('test 1')
+        end
+      end
+
+      describe 'representative_value_for_array' do
+        it 'always gets the highest value closest to the mean of the values on a tie' do
+          data = [1, 2, 3, 4]
+          result = subject.send(:representative_value_for_array, data)
+          expect(result).to eq(3)
+        end
+
+        it 'returns the highest value from a hash of values' do
+          data = [5]
+          result = subject.send(:representative_value_for_array, data)
+          expect(result).to eq(5)
+        end
+      end
+
+      describe 'closest_value' do
+        it 'returns the value when both values are the same' do
+          result = subject.send(:closest_value, 3, 3, 3)
+          expect(result).to eq(3)
+        end
+
+        it 'returns the larger value if the values are equidistant from mean' do
+          result = subject.send(:closest_value, 4, 3, 3.5)
+          expect(result).to eq(4)
+        end
+
+        it 'returns the smaller value if it is closer to the mean' do
+          result = subject.send(:closest_value, 4, 3, 3.4)
+          expect(result).to eq(3)
+        end
+
+        it 'returns the larger value if it is closer to the mean' do
+          result = subject.send(:closest_value, 4, 3, 3.7)
+          expect(result).to eq(4)
         end
       end
 
@@ -224,3 +261,4 @@ module Physiqual
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
PS: roqua/roqua has classlength max 300, with the comment "As long as they're simple." So I think 200 is fine. The alternative would be moving code that should be in a class outside of that class, which is worse, I think.

This fixes #8.